### PR TITLE
fixed results being 0 wpm after 1st try.

### DIFF
--- a/Speed Typing Test Python/speed typing.py
+++ b/Speed Typing Test Python/speed typing.py
@@ -9,7 +9,7 @@ import random
 class Game:
    
     def __init__(self):
-        self.w=750
+        self.w=950
         self.h=500
         self.reset=True
         self.active = False
@@ -145,7 +145,7 @@ class Game:
 
         self.input_text=''
         self.word = ''
-        self.time_start = 0
+        # self.time_start = 0
         self.total_time = 0
         self.wpm = 0
 


### PR DESCRIPTION
- The first try has good results. However, every try after that gets 0 wpm. This is because we take how many words typed and divide by time lapsed. However after the first try our time lapsed ends up incorrectly just being epoch time, instead of the actual time lapsed. Because we divide by this big number, we get 0, hence the 0 wpm. This is due to time_start being set to 0 in the reset_game function. I simply commented it out, and it resolved the issue.
- also widened the window a little bit, as the text scrolls off for me for some sentences